### PR TITLE
feat: supabase 쿼리 추가

### DIFF
--- a/apis/group.ts
+++ b/apis/group.ts
@@ -1,0 +1,30 @@
+import { createSupabaseServerSideClient } from "@/lib/supabase/serverSideClient";
+
+export const getGroupById = async (group_id: string) => {
+  const supabase = await createSupabaseServerSideClient();
+  const result = await supabase
+    .from("group")
+    .select("*")
+    .eq("id", group_id)
+    .is("deleted_at", null);
+  return result.data;
+};
+
+export const fetchGroupByUserId = async (userId: string) => {
+  const supabase = await createSupabaseServerSideClient();
+  const result = await supabase
+    .from("group")
+    .select("*")
+    .eq("user_id", userId)
+    .is("deleted_at", null);
+  return result.data;
+};
+
+export const createGroup = async (name: string, intro: string = "") => {
+  const supabase = await createSupabaseServerSideClient();
+  const result = await supabase
+    .from("group")
+    .insert([{ name, intro }])
+    .select();
+  return result.data;
+};

--- a/apis/group.ts
+++ b/apis/group.ts
@@ -7,7 +7,8 @@ export const getGroupById = async (group_id: string) => {
     .select("*")
     .eq("id", group_id)
     .is("deleted_at", null);
-  return result.data;
+
+  return result;
 };
 
 export const fetchGroupByUserId = async (userId: string) => {
@@ -17,7 +18,8 @@ export const fetchGroupByUserId = async (userId: string) => {
     .select("*")
     .eq("user_id", userId)
     .is("deleted_at", null);
-  return result.data;
+
+  return result;
 };
 
 export const createGroup = async (name: string, intro: string = "") => {
@@ -26,5 +28,6 @@ export const createGroup = async (name: string, intro: string = "") => {
     .from("group")
     .insert([{ name, intro }])
     .select();
-  return result.data;
+
+  return result;
 };

--- a/apis/member.ts
+++ b/apis/member.ts
@@ -1,0 +1,17 @@
+import { createSupabaseServerSideClient } from "@/lib/supabase/serverSideClient";
+
+export const fetchMemberByGroupId = async (group_id: string) => {
+  const supabase = await createSupabaseServerSideClient();
+  const result = await supabase
+    .from("member")
+    .select(`*, profile:user_id ( full_name, avatar_url )`)
+    .eq("group_id", group_id)
+    .is("deleted_at", null);
+  return result.data;
+};
+
+export const createMember = async (group_id: string) => {
+  const supabase = await createSupabaseServerSideClient();
+  const result = await supabase.from("member").insert([{ group_id }]).select();
+  return result.data;
+};

--- a/apis/member.ts
+++ b/apis/member.ts
@@ -7,11 +7,12 @@ export const fetchMemberByGroupId = async (group_id: string) => {
     .select(`*, profile:user_id ( full_name, avatar_url )`)
     .eq("group_id", group_id)
     .is("deleted_at", null);
-  return result.data;
+
+  return result;
 };
 
 export const createMember = async (group_id: string) => {
   const supabase = await createSupabaseServerSideClient();
-  const result = await supabase.from("member").insert([{ group_id }]).select();
-  return result.data;
+
+  return result;
 };

--- a/apis/pray.ts
+++ b/apis/pray.ts
@@ -1,0 +1,21 @@
+import { createSupabaseServerSideClient } from "@/lib/supabase/serverSideClient";
+
+export const createPray = async (pray_sheet_id: string) => {
+  const supabase = await createSupabaseServerSideClient();
+  const result = await supabase
+    .from("pray")
+    .insert([{ pray_sheet_id }])
+    .select();
+
+  return result;
+};
+
+export const fetchPray = async (pray_sheet_id: string) => {
+  const supabase = await createSupabaseServerSideClient();
+  const result = await supabase
+    .from("pray")
+    .select("*")
+    .eq("pray_sheet_id", pray_sheet_id);
+
+  return result;
+};

--- a/apis/praySheet.ts
+++ b/apis/praySheet.ts
@@ -7,17 +7,25 @@ export const getPraySheetById = async (pray_sheet_id: string) => {
     .select("*")
     .eq("id", pray_sheet_id)
     .is("deleted_at", null);
-  return result.data;
+
+  return result;
 };
 
-export const fetchPraySheetByGroupId = async (group_id: string) => {
+export const fetchPraySheetByGroupId = async (
+  group_id: string,
+  start_at: string,
+  end_at: string
+) => {
   const supabase = await createSupabaseServerSideClient();
   const result = await supabase
     .from("pray_sheet")
     .select("*")
     .eq("group_id", group_id)
-    .is("deleted_at", null);
-  return result.data;
+    .is("deleted_at", null)
+    .gte("created_at", start_at)
+    .lte("created_at", end_at);
+
+  return result;
 };
 
 export const createPraySheet = async (group_id: string, content: string) => {
@@ -26,5 +34,6 @@ export const createPraySheet = async (group_id: string, content: string) => {
     .from("pray_sheet")
     .insert([{ group_id, content }])
     .select();
-  return result.data;
+
+  return result;
 };

--- a/apis/praySheet.ts
+++ b/apis/praySheet.ts
@@ -1,0 +1,30 @@
+import { createSupabaseServerSideClient } from "@/lib/supabase/serverSideClient";
+
+export const getPraySheetById = async (pray_sheet_id: string) => {
+  const supabase = await createSupabaseServerSideClient();
+  const result = await supabase
+    .from("pray_sheet")
+    .select("*")
+    .eq("id", pray_sheet_id)
+    .is("deleted_at", null);
+  return result.data;
+};
+
+export const fetchPraySheetByGroupId = async (group_id: string) => {
+  const supabase = await createSupabaseServerSideClient();
+  const result = await supabase
+    .from("pray_sheet")
+    .select("*")
+    .eq("group_id", group_id)
+    .is("deleted_at", null);
+  return result.data;
+};
+
+export const createPraySheet = async (group_id: string, content: string) => {
+  const supabase = await createSupabaseServerSideClient();
+  const result = await supabase
+    .from("pray_sheet")
+    .insert([{ group_id, content }])
+    .select();
+  return result.data;
+};

--- a/apis/user.ts
+++ b/apis/user.ts
@@ -1,0 +1,7 @@
+import { createSupabaseServerSideClient } from "@/lib/supabase/serverSideClient";
+
+export const getUser = async ({ serverComponent = false }) => {
+  const supabase = await createSupabaseServerSideClient(serverComponent);
+  const user = await supabase.auth.getUser();
+  return user?.data?.user;
+};

--- a/apis/user.ts
+++ b/apis/user.ts
@@ -2,6 +2,6 @@ import { createSupabaseServerSideClient } from "@/lib/supabase/serverSideClient"
 
 export const getUser = async ({ serverComponent = false }) => {
   const supabase = await createSupabaseServerSideClient(serverComponent);
-  const user = await supabase.auth.getUser();
-  return user?.data?.user;
+  const result = await supabase.auth.getUser();
+  return result?.data?.user;
 };

--- a/types/tableSchema.ts
+++ b/types/tableSchema.ts
@@ -97,7 +97,7 @@ export type Database = {
           created_at: string
           deleted_at: string | null
           id: string
-          pray_sheed_id: string | null
+          pray_sheet_id: string | null
           updated_at: string | null
           user_id: string | null
         }
@@ -105,7 +105,7 @@ export type Database = {
           created_at?: string
           deleted_at?: string | null
           id?: string
-          pray_sheed_id?: string | null
+          pray_sheet_id?: string | null
           updated_at?: string | null
           user_id?: string | null
         }
@@ -113,14 +113,14 @@ export type Database = {
           created_at?: string
           deleted_at?: string | null
           id?: string
-          pray_sheed_id?: string | null
+          pray_sheet_id?: string | null
           updated_at?: string | null
           user_id?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: "pray_pray_sheed_id_fkey"
-            columns: ["pray_sheed_id"]
+            foreignKeyName: "pray_pray_sheet_id_fkey"
+            columns: ["pray_sheet_id"]
             isOneToOne: false
             referencedRelation: "pray_sheet"
             referencedColumns: ["id"]

--- a/types/tableSchema.ts
+++ b/types/tableSchema.ts
@@ -9,7 +9,211 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
-      [_ in never]: never
+      group: {
+        Row: {
+          created_at: string
+          deleted_at: string | null
+          id: string
+          intro: string | null
+          name: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          intro?: string | null
+          name?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          intro?: string | null
+          name?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "group_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      member: {
+        Row: {
+          created_at: string
+          deleted_at: string | null
+          group_id: string | null
+          id: string
+          pray_summary: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          deleted_at?: string | null
+          group_id?: string | null
+          id?: string
+          pray_summary?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          deleted_at?: string | null
+          group_id?: string | null
+          id?: string
+          pray_summary?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "member_group_id_fkey"
+            columns: ["group_id"]
+            isOneToOne: false
+            referencedRelation: "group"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "member_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      pray: {
+        Row: {
+          created_at: string
+          deleted_at: string | null
+          id: string
+          pray_sheed_id: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          pray_sheed_id?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          deleted_at?: string | null
+          id?: string
+          pray_sheed_id?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "pray_pray_sheed_id_fkey"
+            columns: ["pray_sheed_id"]
+            isOneToOne: false
+            referencedRelation: "pray_sheet"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pray_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      pray_sheet: {
+        Row: {
+          content: string | null
+          created_at: string
+          deleted_at: string | null
+          group_id: string | null
+          id: string
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          content?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          group_id?: string | null
+          id?: string
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          content?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          group_id?: string | null
+          id?: string
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "pray_sheet_group_id_fkey"
+            columns: ["group_id"]
+            isOneToOne: false
+            referencedRelation: "group"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pray_sheet_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profiles: {
+        Row: {
+          avatar_url: string | null
+          full_name: string | null
+          id: string
+          updated_at: string | null
+          username: string | null
+          website: string | null
+        }
+        Insert: {
+          avatar_url?: string | null
+          full_name?: string | null
+          id: string
+          updated_at?: string | null
+          username?: string | null
+          website?: string | null
+        }
+        Update: {
+          avatar_url?: string | null
+          full_name?: string | null
+          id?: string
+          updated_at?: string | null
+          username?: string | null
+          website?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profiles_id_fkey"
+            columns: ["id"]
+            isOneToOne: true
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Views: {
       [_ in never]: never


### PR DESCRIPTION
### 체크리스트
- `group`
    1. 유저의 모든 그룹 조회, 특정 그룹 조회
    2. 그룹 생성
- `member`
    1. 그룹 아이디를 통해 member 조회
    2. 맴버 생성
- `pray_sheet`
    1. 그룹에 포함된 기도제목 시트 날짜 기준 조회, 특정 기도제목 시트 조회
    2. 기도제목 시트 생성
- `pray`
    1. 특정 기도제목 시트의 기도 조회
    2. 기도 생성

### 노션링크
https://www.notion.so/mmyeong/supabase-b01ca946f0064b22964d0d8f38072fb4?pvs=4